### PR TITLE
Unify time measuring units in all implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [ "master" ]
 
 env:
-  STEP: 16
-  STOP: 256
+  STEP: 64
+  STOP: 512
   TIMEOUT: 1
   ATTEMPTS: 3
 

--- a/C#/Program.cs
+++ b/C#/Program.cs
@@ -7,7 +7,7 @@
  * February 8, 2013
  *
  * Syntax: queens [-test] [N]
- * 
+ *
  ******************************************************************************/
 
 using System;
@@ -42,7 +42,7 @@ namespace Queens
             time = DateTime.Now.Ticks - time;
 
             if (testing)
-                Console.WriteLine(chess.Steps + "\t" + chess.Discards + "\t" + time / 10000);
+                Console.WriteLine(chess.Steps + "\t" + chess.Discards + "\t" + time / 10);
             else
             {
                 Console.WriteLine(chess.ToString());

--- a/JS/queens.js
+++ b/JS/queens.js
@@ -27,16 +27,16 @@ if (isNaN(n) || n < 4) {
 
 var chess = new libchess.Chess(n)
 var hrtime = process.hrtime()
-var time = hrtime[0] + hrtime[1] / 1e9
+var time = hrtime[0] *1e6 + hrtime[1] / 1e3
 
 chess.solve()
 
 hrtime = process.hrtime()
-time = parseInt((hrtime[0] + hrtime[1] / 1e9 - time) * 1000)
+time = parseInt((hrtime[0] *1e6 + hrtime[1] / 1e3 - time))
 
 if (testing)
     console.log(String(chess.steps()) + "\t" + chess.discards() + "\t" + time)
 else {
     console.log(String(chess))
-    console.log("Solved in " + chess.steps() + " steps. Time: " + time + " ms.")
+    console.log("Solved in " + chess.steps() + " steps. Time: " + time / 1000 + " ms.")
 }

--- a/Java/queens/Main.java
+++ b/Java/queens/Main.java
@@ -42,16 +42,16 @@ public class Main {
         }
 
         chess = new Chess(n);
-        time = System.currentTimeMillis();
+        time = System.nanoTime();
         chess.solve();
-        time = System.currentTimeMillis() - time;
+        time = System.nanoTime() - time;
 
         if (testing) {
-            System.out.println(chess.getSteps() + "\t" + chess.getDiscards() + "\t" + time);
+            System.out.println(chess.getSteps() + "\t" + chess.getDiscards() + "\t" + time / 1000);
         } else {
             System.out.println(chess);
             System.out.print("Solved in " + chess.getSteps() + " steps. ");
-            System.out.println("Time: " + time + " ms.");
+            System.out.println("Time: " + time / 1000000 + " ms.");
         }
     }
 }

--- a/PHP/queens.php
+++ b/PHP/queens.php
@@ -34,7 +34,7 @@ while ($n < 4)
 $chess = new Chess($n);
 $time = microtime(true);
 $chess->solve();
-$time = (int)((microtime(true) - $time) * 1000);
+$time = (int)((microtime(true) - $time) * 1e6);
 $steps = $chess->steps();
 $discards = $chess->discards();
 
@@ -42,5 +42,6 @@ if ($testing)
     echo "$steps\t$discards\t$time\n";
 else {
     echo $chess;
+    $time /= 1000;
     echo "Solved in $steps steps. Time: $time ms.\n";
 }

--- a/Python/queens.py
+++ b/Python/queens.py
@@ -37,10 +37,10 @@ if __name__ == "__main__":
     chess = Chess(n)
     time = perf_counter()
     chess.solve()
-    time = int((perf_counter() - time) * 1000)
+    time = int((perf_counter() - time) * 1e6)
 
     if testing:
         print(str(chess.steps()) + "\t" + str(chess.discards()) + "\t" + str(time));
     else:
         print(chess)
-        print("Solved in", chess.steps(), "steps. Time:", time, "ms.")
+        print("Solved in", chess.steps(), "steps. Time:", time / 1000, "ms.")


### PR DESCRIPTION
After researching #2, we discovered that the following implementations were reporting the time in milliseconds:

- JavaScript
- Java
- C#
- Python
- PHP

This was causing an unfair advantage to these languages in the comparison.

## Fix proposed

Every implementation must report the execution time in milliseconds at the testing output.